### PR TITLE
CVE-2024-13009 In Eclipse Jetty a buffer can be incorrectly released …

### DIFF
--- a/OpenICF-groovy-connector/pom.xml
+++ b/OpenICF-groovy-connector/pom.xml
@@ -183,7 +183,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.51.v20230217</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -213,14 +213,9 @@
             <dependency>
                 <groupId>org.openidentityplatform.opendj</groupId>
                 <artifactId>opendj-parent</artifactId>
-                <version>4.9.4</version>
+                <version>4.9.5-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>2.4.21</version>
             </dependency>
             <dependency>
                 <groupId>org.openidentityplatform.openicf.framework</groupId>
@@ -299,24 +294,6 @@
                 <artifactId>rxjava</artifactId>
                 <version>1.2.0</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>9.4.57.v20241219</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>9.4.57.v20241219</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-server</artifactId>
-                <version>9.4.57.v20241219</version>
-                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
…when confronted with a gzip error when inflating a request body.